### PR TITLE
Update API sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This Redmine CRM 3CX integration plugin offers a configuration template along wi
 
 To access the contacts API in the Redmine CRM plugin, the current user must have the `:use_api` permission. This permission can be found under the Project permissions. It is important to note that the user account must have the `use_api` permission for the project that the contacts are part of, otherwise the project contacts will be skipped.
 
+When multiple contacts share the same phone number, the API will prioritize individual contacts over company contacts in the results. This means that if both a person and a company have the same phone number, the person's contact details will appear first in the response.
+
 ## Production Environment
 
 ### Preconditions

--- a/app/controllers/crm_api_controller.rb
+++ b/app/controllers/crm_api_controller.rb
@@ -21,7 +21,7 @@ class CrmApiController < ApplicationController
   def find_contacts
     phone_number = ContactSerializer.normalize_phone_number(phone_params)
 
-    @contacts = Contact.joins(:projects).filter do |contact|
+    @contacts = Contact.joins(:projects).order(:is_company).filter do |contact|
       contact.phones.map { |phone| ContactSerializer.normalize_phone_number(phone) }.include?(phone_number)
     end.filter do |contact|
       User.current.allowed_to?(:use_api, contact.project)

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -1,4 +1,3 @@
-# This will guess the User class
 FactoryBot.define do
   factory :user do
     login { "myuser" }

--- a/test/functional/crm_api_controller_test.rb
+++ b/test/functional/crm_api_controller_test.rb
@@ -76,6 +76,15 @@ class CrmApiControllerTest < ActionController::TestCase
     assert_equal({contacts: []}.to_json, response.body)
   end
 
+  def test_index_company_and_person_with_same_phone_number
+    @company = create(:contact, project: @contact.project, first_name: "Example AG", last_name: nil, company: nil,  is_company: true)
+    get_contact(@company.phone)
+    assert_response(:success)
+    assert_equal 2, JSON.parse(response.body)["contacts"].size
+    assert_equal @contact.id, JSON.parse(response.body)["contacts"][0]["id"]
+    assert_equal @company.id, JSON.parse(response.body)["contacts"][1]["id"]
+  end
+
   private
 
   def get_contact_assert_success

--- a/test/system/export_test.rb
+++ b/test/system/export_test.rb
@@ -11,6 +11,7 @@ class ExportTest < ActiveSupport::TestCase
 
     create(:contact, first_name: "Borris", last_name: "Doe", company: "Example AG", phone: nil)
     create(:contact, first_name: "John", last_name: "Doe", company: "Example AG", phone: "0781234567")
+    create(:contact, first_name: "Other", last_name: "Person", company: "Example AG", phone: "+41 78 123 45 67, 078 123 45 67, 078 123 45 67")
     create(:contact, first_name: "Another", last_name: "Person", company: "Example AG", phone: "+41 (0) 78 123 45 67")
     create(:contact, first_name: "Yet", last_name: "Another", company: "Example AG", phone: "+41 78 123 45 67")
 

--- a/test/system/export_test.rb
+++ b/test/system/export_test.rb
@@ -14,6 +14,8 @@ class ExportTest < ActiveSupport::TestCase
     create(:contact, first_name: "Other", last_name: "Person", company: "Example AG", phone: "+41 78 123 45 67, 078 123 45 67, 078 123 45 67")
     create(:contact, first_name: "Another", last_name: "Person", company: "Example AG", phone: "+41 (0) 78 123 45 67")
     create(:contact, first_name: "Yet", last_name: "Another", company: "Example AG", phone: "+41 78 123 45 67")
+    create(:contact, first_name: "MyCompany", last_name: nil, phone: "+41 78 123 45 69", is_company: true)
+
     Rake::Task["redmine_3cx:export"].invoke
     @csv = CSV.read("tmp/contacts.csv")
   end
@@ -25,6 +27,7 @@ class ExportTest < ActiveSupport::TestCase
       Other,Person,Example AG,0781234567,0781234567,0781234567,,,,
       Another,Person,Example AG,0781234567,,,,,,
       Yet,Another,Example AG,0781234567,,,,,,
+      MyCompany,,Example AG,0781234569,,,,,,
     CSV
   end
 end

--- a/test/system/export_test.rb
+++ b/test/system/export_test.rb
@@ -11,10 +11,8 @@ class ExportTest < ActiveSupport::TestCase
 
     create(:contact, first_name: "Borris", last_name: "Doe", company: "Example AG", phone: nil)
     create(:contact, first_name: "John", last_name: "Doe", company: "Example AG", phone: "0781234567")
-    create(:contact, first_name: "Other", last_name: "Person", company: "Example AG", phone: "+41 78 123 45 67, 078 123 45 67,078 123 45 67")
     create(:contact, first_name: "Another", last_name: "Person", company: "Example AG", phone: "+41 (0) 78 123 45 67")
     create(:contact, first_name: "Yet", last_name: "Another", company: "Example AG", phone: "+41 78 123 45 67")
-    create(:contact, first_name: "MyCompany", last_name: nil, phone: "+41 78 123 45 69", is_company: true)
 
     Rake::Task["redmine_3cx:export"].invoke
     @csv = CSV.read("tmp/contacts.csv")
@@ -27,7 +25,6 @@ class ExportTest < ActiveSupport::TestCase
       Other,Person,Example AG,0781234567,0781234567,0781234567,,,,
       Another,Person,Example AG,0781234567,,,,,,
       Yet,Another,Example AG,0781234567,,,,,,
-      MyCompany,,Example AG,0781234569,,,,,,
     CSV
   end
 end

--- a/test/system/export_test.rb
+++ b/test/system/export_test.rb
@@ -11,7 +11,7 @@ class ExportTest < ActiveSupport::TestCase
 
     create(:contact, first_name: "Borris", last_name: "Doe", company: "Example AG", phone: nil)
     create(:contact, first_name: "John", last_name: "Doe", company: "Example AG", phone: "0781234567")
-    create(:contact, first_name: "Other", last_name: "Person", company: "Example AG", phone: "+41 78 123 45 67, 078 123 45 67, 078 123 45 67")
+    create(:contact, first_name: "Other", last_name: "Person", company: "Example AG", phone: "+41 78 123 45 67, 078 123 45 67,078 123 45 67")
     create(:contact, first_name: "Another", last_name: "Person", company: "Example AG", phone: "+41 (0) 78 123 45 67")
     create(:contact, first_name: "Yet", last_name: "Another", company: "Example AG", phone: "+41 78 123 45 67")
     create(:contact, first_name: "MyCompany", last_name: nil, phone: "+41 78 123 45 69", is_company: true)

--- a/test/system/settings_test.rb
+++ b/test/system/settings_test.rb
@@ -58,7 +58,11 @@ class SettingsTest < ApplicationSystemTestCase
 
   def assert_active_state(state)
     Setting.clear_cache
-    assert_equal state, Setting.plugin_redmine_3cx[:active]
+    if state.nil?
+      assert_nil Setting.plugin_redmine_3cx[:active]
+    else
+      assert_equal state, Setting.plugin_redmine_3cx[:active]
+    end
   end
 
   def visit_settings_page


### PR DESCRIPTION
[TICKET-23811](https://redmine.renuo.ch/issues/23811)

First show contacts, then companies because company records usually only have the `first_name` set.