### PR TITLE
Fix type error

### DIFF
--- a/app/views/crm_template/template.xml.erb
+++ b/app/views/crm_template/template.xml.erb
@@ -40,7 +40,7 @@
         <Output Type="PhoneOther" Passes="0" Value="[PhoneOther]" />
         <Output Type="EntityId" Passes="0" Value="[ContactId]" />
         <Output Type="EntityType" Passes="0" Value="Contacts" />
-        <Output Type="ContactUrl" Passes="0" Value="https://[Domain]/contacts/[ContactID]" />
+        <Output Type="ContactUrl" Passes="0" Value="https://[Domain]/contacts/[ContactId]" />
       </Outputs>
     </Scenario>
   </Scenarios>


### PR DESCRIPTION
Clicking the link to go to the CRM contact, opened on the default contact page, because of a type error in the variable "ContactId"