### PR TITLE
Normalize 00 prefix, handle Lucerne numbers

### DIFF
--- a/app/models/contact_serializer.rb
+++ b/app/models/contact_serializer.rb
@@ -22,10 +22,17 @@ class ContactSerializer
     end
 
     def normalize_phone_number(phone_number)
-      phone_number.to_s.gsub(/[^0-9]/, "")
-        .sub(/^(0041|041|41)/, "")
-        .sub(/^00/, "0")
-        .rjust(10, "0")
+      n = phone_number.to_s.gsub(/[^0-9]/, "")
+      # Strip 0041, 041, or 41 prefixes IF the number is long enough to include a country code.
+      # "n.length > 10" protects Lucerne numbers (e.g. 041 222 33 44), which are exactly 10.
+      n = n[4..] if n.start_with?("0041") && n.length > 10
+      n = n[3..] if n.start_with?("041") && n.length > 10
+      n = n[2..] if n.start_with?("41") && n.length > 10
+
+      n = n[1..] if n.start_with?("00")
+      n = "0" + n if n.length == 9
+
+      n.rjust(10, "0")
     end
   end
 end

--- a/app/models/contact_serializer.rb
+++ b/app/models/contact_serializer.rb
@@ -22,7 +22,10 @@ class ContactSerializer
     end
 
     def normalize_phone_number(phone_number)
-      phone_number.gsub(/[^+0-9]/, "").gsub(/^[+0]41/, "").rjust(10, "0")
+      phone_number.to_s.gsub(/[^0-9]/, "")
+        .sub(/^(0041|041|41)/, "")
+        .sub(/^00/, "0")
+        .rjust(10, "0")
     end
   end
 end

--- a/test/unit/contact_serializer_test.rb
+++ b/test/unit/contact_serializer_test.rb
@@ -45,7 +45,8 @@ class ContactSerializerTest < ActiveSupport::TestCase
       ["0449998877", "++41 44-999.88.77"],
       ["0315556677", "Tel: 031/555 66 77"],
       ["0794445566", "79 444 55 66"],
-      ["0431112233", "431112233"]
+      ["0431112233", "431112233"],
+      ["0412223344", "041 222 33 44"] # Lucerne
     ].each do |expected, phone_number|
       assert_equal(expected, ContactSerializer.normalize_phone_number(phone_number))
     end

--- a/test/unit/contact_serializer_test.rb
+++ b/test/unit/contact_serializer_test.rb
@@ -42,6 +42,10 @@ class ContactSerializerTest < ActiveSupport::TestCase
       ["0791112233", "00 79 111 22 33"],
       ["0781234567", "0041 78 123 45 67"],
       ["0781234567", "00 41 78 123 45 67"],
+      ["0449998877", "++41 44-999.88.77"],
+      ["0315556677", "Tel: 031/555 66 77"],
+      ["0794445566", "79 444 55 66"],
+      ["0431112233", "431112233"]
     ].each do |expected, phone_number|
       assert_equal(expected, ContactSerializer.normalize_phone_number(phone_number))
     end

--- a/test/unit/contact_serializer_test.rb
+++ b/test/unit/contact_serializer_test.rb
@@ -37,7 +37,11 @@ class ContactSerializerTest < ActiveSupport::TestCase
       ["0794567890", "079 456 78 90"],
       ["0314567890", "+41 (0)31 456 78 90"],
       ["0442345678", "044 234 56 78"],
-      ["0442345678", "Direkt: 044 234 56 78"]
+      ["0442345678", "Direkt: 044 234 56 78"],
+      ["0791112233", "0079 111 22 33"],
+      ["0791112233", "00 79 111 22 33"],
+      ["0781234567", "0041 78 123 45 67"],
+      ["0781234567", "00 41 78 123 45 67"],
     ].each do |expected, phone_number|
       assert_equal(expected, ContactSerializer.normalize_phone_number(phone_number))
     end


### PR DESCRIPTION
[TICKET-23811](https://redmine.renuo.ch/issues/23811)

According to the logs, sometimes we receive calls like `0041*********`. These should be properly normalized like the rest.
I also decided to add more edge cases to test against for more certainty.

We don't have 3CX logs that show that the double prefixed variant of a phone number lead to a contact number not being found. We have some instances where even a properly normalized number would not be found. Either way the normalizer handles this case **incorrectly** at the moment.

Although not explicitly stated in the ticket,  I noticed that we errornously remove the 041 prefix for Luzerne numbers.
This could lead to problems so I updated the normalization. Didn't find an instance of it in our logs but it is another case I'd like to avoid.



