### PR TITLE
Do not depend on google drive for redmine contacts

### DIFF
--- a/.semaphore/bin/setup_redmine_contacts
+++ b/.semaphore/bin/setup_redmine_contacts
@@ -3,8 +3,13 @@
 set -euo pipefail
 
 cd ~/redmine/plugins
-curl -L -o redmine_contacts.zip "$REDMINE_CRM_DOWNLOAD_URL"
-unzip redmine_contacts.zip
+git clone --depth 1 --branch develop --single-branch --no-checkout https://github.com/renuo/renuo-redmine.git renuo-redmine-tmp
+cd renuo-redmine-tmp
+git sparse-checkout set plugins/redmine_contacts
+git checkout
+cp -r plugins/redmine_contacts ~/redmine/plugins/redmine_contacts
+cd ~/redmine/plugins
+rm -rf renuo-redmine-tmp
 cd ~/redmine/plugins/redmine_contacts
 sed -i '1s/^/source "https:\/\/rubygems.org"\n/' Gemfile
 bundle install --path ~/vendor/redmine-bundle --without development test

--- a/.semaphore/bin/setup_redmine_contacts
+++ b/.semaphore/bin/setup_redmine_contacts
@@ -2,14 +2,15 @@
 
 set -euo pipefail
 
+GITHUB_TOKEN="${BUNDLE_GITHUB__COM%%:*}"
 cd ~/redmine/plugins
-git clone --depth 1 --branch develop --single-branch --no-checkout https://github.com/renuo/renuo-redmine.git renuo-redmine-tmp
-cd renuo-redmine-tmp
-git sparse-checkout set plugins/redmine_contacts
-git checkout
-cp -r plugins/redmine_contacts ~/redmine/plugins/redmine_contacts
-cd ~/redmine/plugins
-rm -rf renuo-redmine-tmp
+curl -L -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/renuo/renuo-redmine/tarball/develop \
+  -o renuo-redmine.tar.gz
+mkdir -p renuo-redmine-tmp
+tar -xzf renuo-redmine.tar.gz -C renuo-redmine-tmp --strip-components=1
+cp -r renuo-redmine-tmp/plugins/redmine_contacts ~/redmine/plugins/redmine_contacts
+rm -rf renuo-redmine-tmp renuo-redmine.tar.gz
 cd ~/redmine/plugins/redmine_contacts
 sed -i '1s/^/source "https:\/\/rubygems.org"\n/' Gemfile
 bundle install --path ~/vendor/redmine-bundle --without development test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,6 +8,7 @@ agent:
 global_job_config:
   secrets:
     - name: redmine_3cx
+    - name: bundle-github
   env_vars:
     - name: RAILS_ENV
       value: test


### PR DESCRIPTION
We experienced issues because the redmine_contacts was updated in our renuo-redmine but redmine_3cx was not fetching the latest version of redmine_contacts since it was duplicated on google drive.

This PR updates the CI steps to get the redmine_contacts plugin folder from the current version of renuo-redmine.

This allows us to continue with the upgrade